### PR TITLE
Fix an error happening when PUT-ing an extension field to an instance

### DIFF
--- a/scim2_server/utils.py
+++ b/scim2_server/utils.py
@@ -59,9 +59,11 @@ def merge_resources(target: Resource, updates: BaseModel):
         if isinstance(getattr(updates, set_attribute), Extension):
             # This is a model extension, handle it as its own resource
             # and don't simply overwrite it
-            merge_resources(
-                getattr(target, set_attribute), getattr(updates, set_attribute)
-            )
+            target_extension = getattr(target, set_attribute)
+            if target_extension is None:
+                setattr(target, set_attribute, getattr(updates, set_attribute))
+            else:
+                merge_resources(target_extension, getattr(updates, set_attribute))
             continue
         new_value = getattr(updates, set_attribute)
         if mutability == Mutability.immutable and getattr(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -368,3 +368,20 @@ class TestUtils:
         u = User()
         with pytest.raises(SCIMException, match="immutable"):
             get_or_create(u, "groups", True)
+
+    def test_merge_resources_none_extension(self):
+        """Test adding an extension parameter with merge_resources."""
+        target = User[EnterpriseUser](user_name="test")
+        assert target[EnterpriseUser] is None
+
+        payload = {
+            "userName": "test",
+            "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+                "employeeNumber": "12345"
+            },
+        }
+        update = User[EnterpriseUser].model_validate(payload)
+
+        merge_resources(target, update)
+
+        assert target[EnterpriseUser].employee_number == "12345"


### PR DESCRIPTION
when there was none before